### PR TITLE
Use specified image for Azure Proxy VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Under the `azure` section, edit following values as per your configuration:
   offer|publisher|sku|version|
   Ex: CentOS|OpenLogic|7_9|latest|
   ```
+* `azure_proxy_image_reference` allows you to specify the CentOS image SKU that will be used for the optional proxy machine.
+  If this property is not specified, then the value of `azure_image_reference` will be used instead.
 * `numnodes` to change the cluster size in terms of number of nodes deployed
 * `data_disk_count` to specify how many persistent data disks are attached to each node and will be used by HDFS.
    If you would prefer to use ephemeral / storage for Azure clusters, please follow [these steps](docs/azure-ephemeral-disks.md).

--- a/ansible/roles/azure/tasks/create_optional_proxy.yml
+++ b/ansible/roles/azure/tasks/create_optional_proxy.yml
@@ -74,15 +74,19 @@
         key_data: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
     os_disk_caching: ReadWrite
     image:
-      offer: CentOS
-      publisher: OpenLogic
-      sku: 7_9
-      version: latest
+      offer: "{{ image_offer if image_offer else omit }}"
+      publisher: "{{ image_publisher if image_publisher else omit }}"
+      sku: "{{ image_sku if image_sku else omit }}"
+      version: "{{ image_version if image_version else omit }}"
     managed_disk_type: "{{ osdisk_sku }}"
     data_disks:
      - lun: 0
        disk_size_gb: 64
        managed_disk_type: "{{ data_disk_sku }}"
   vars:
+  - image_offer: "{{ azure_proxy_image_reference.split('|')[0] }}"
+  - image_publisher: "{{ azure_proxy_image_reference.split('|')[1] }}"
+  - image_sku: "{{ azure_proxy_image_reference.split('|')[2] }}"
+  - image_version: "{{ azure_proxy_image_reference.split('|')[3] }}"
   - osdisk_sku: "{{ 'Premium_LRS' if azure_proxy_host_vm_sku in premiumio_capable_skus else 'Standard_LRS' }}"
   when: azure_proxy_host is defined and azure_proxy_host and azure_proxy_host != None

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -125,6 +125,11 @@ vmss_priority = Regular
 # Azure image reference defined as a pipe-delimited string in the format offer|publisher|sku|version|
 # Please refer 'Launching an Azure cluster' section of the README before making changes
 azure_image_reference = CentOS|OpenLogic|7_9|latest|
+# Azure image reference defined as a pipe-delimited string in the format offer|publisher|sku|version|
+# This is the image that will be used for the proxy machine (if specified by azure_proxy_host). If
+# this is not set, then the value of azure_image_reference will be used on the proxy.
+# Please refer 'Launching an Azure cluster' section of the README before making changes
+#azure_proxy_image_reference = CentOS|OpenLogic|7_9|latest|
 # Size of the cluster to provision.
 # A virtual machine scale set (VMSS) with these many VMs will be created.
 # The minimum allowed size for this is 3 nodes for non-HA & 4 nodes for HA setup

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -189,6 +189,13 @@ class AzureDeployConfig(BaseConfig):
     def azure_image_reference(self):
         return self.get("azure", "azure_image_reference")
 
+    @ansible_host_var
+    def azure_proxy_image_reference(self):
+        apir = self.get("azure", "azure_proxy_image_reference", fallback=None)
+        if apir is None or apir == "":
+            apir = self.get("azure", "azure_image_reference")
+        return apir
+
     @ansible_host_var(name="az_oms_integration_needed")
     @default(False)
     @is_valid(is_in([True, False]))


### PR DESCRIPTION
Rather than having a hard-coded value for the SKU/image to use for the
Azure proxy VM, default to using the value specified for the rest of the
cluster. The value can be overridden specifically for the proxy by
setting azure_proxy_image_reference in the azure section of the config.